### PR TITLE
COMP: Fix dcm2niix install step

### DIFF
--- a/SuperBuild/External_dcm2niix.cmake
+++ b/SuperBuild/External_dcm2niix.cmake
@@ -67,7 +67,6 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       #-DSlicerExecutionModel_DEFAULT_CLI_RUNTIME_ARCHIVE_DIRECTORY:PATH=${SlicerExecutionModel_DEFAULT_CLI_ARCHIVE_OUTPUT_DIRECTORY}
       # Options
       -DBUILD_TESTING:BOOL=OFF
-    INSTALL_COMMAND make install
     DEPENDS
       ${${proj}_DEPENDS}
     )


### PR DESCRIPTION
This commit fixes install step on Windows removing the assumption that
make is the build tool. Without specifying an install step, CMake will
invoke the build tool correctly by default.

Co-authored-by: Lauren O'Donnell <odonnell@bwh.harvard.edu>
Co-authored-by: Sam Horvath <sam.horvath@kitware.com>